### PR TITLE
Use latest aegir instead of non-existing branch

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "url": "https://github.com/ipfs/js-ipfs-api"
   },
   "devDependencies": {
-    "aegir": "ipfs/aegir#next",
+    "aegir": "^12.0.6",
     "chai": "^4.0.2",
     "dirty-chai": "^2.0.0",
     "eslint-plugin-react": "^7.1.0",


### PR DESCRIPTION
Currently, master is broken because of this, since the branch doesn't exists upstream.